### PR TITLE
fix: OpenApi Spec is not pushed with integration tests anymore

### DIFF
--- a/.github/workflows/openapi-doc-check.yml
+++ b/.github/workflows/openapi-doc-check.yml
@@ -1,0 +1,67 @@
+#    Copyright (c) 2024 Contributors to the Eclipse Foundation
+#
+#    See the NOTICE file(s) distributed with this work for additional
+#    information regarding copyright ownership.
+#
+#    This program and the accompanying materials are made available under the
+#    terms of the Apache License, Version 2.0 which is available at
+#    https://www.apache.org/licenses/LICENSE-2.0.
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+
+name: "[BE] Check if OpenApi doc is up to date"
+
+on:
+  schedule:
+    - cron: '0 0 * * *' # run daily at midnight
+  workflow_dispatch:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: 'temurin'
+
+      - name: Check whether OpenApi doc should be updated
+        run: |
+          cd tx-backend
+          mvn test -Dtest=OpenApiDocumentationIT -Dopenapi-doc.generate=true -B
+          differences=$(git diff --name-only | grep OpenApiDocumentationIT.java || echo "")
+          if [[ -n $differences ]]; then
+            echo "The OpenApi document was changed"
+            echo "WAS_FILE_CHANGED=true" >> "$GITHUB_ENV"
+            git
+          else
+            echo "The OpenApi document was not changed"
+            echo "WAS_FILE_CHANGED=false" >> "$GITHUB_ENV"
+          fi
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+        if: ${{ env.WAS_FILE_CHANGED == 'true' }}
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          add-paths: ${{ env.OPENAPI_DOC_FILE_PATH }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: action/openapi-doc-update
+          title: "chore(openapi): updated the OpenApi document"
+          labels: automated
+        if: ${{ env.WAS_FILE_CHANGED == 'true' }}

--- a/tx-backend/src/main/resources/application-integration-spring-boot.yml
+++ b/tx-backend/src/main/resources/application-integration-spring-boot.yml
@@ -116,3 +116,6 @@ irs-edc-client:
       secret: "integration-tests"
 bpdm:
   oAuthClientId: OKTA
+
+openapi-doc:
+  generate: false

--- a/tx-backend/src/test/java/org/eclipse/tractusx/traceability/integration/openapi/OpenApiDocumentationIT.java
+++ b/tx-backend/src/test/java/org/eclipse/tractusx/traceability/integration/openapi/OpenApiDocumentationIT.java
@@ -21,6 +21,7 @@ package org.eclipse.tractusx.traceability.integration.openapi;
 
 import org.eclipse.tractusx.traceability.integration.IntegrationTestSpecification;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.context.junit.jupiter.EnabledIf;
 
 import java.io.File;
 import java.io.IOException;
@@ -30,13 +31,14 @@ import java.util.List;
 import static io.restassured.RestAssured.given;
 import static org.apache.commons.io.FileUtils.writeStringToFile;
 
+@EnabledIf(expression = "${openapi-doc.generate}", loadContext = true)
 class OpenApiDocumentationIT extends IntegrationTestSpecification {
 
     private static final List<String> API_DOCUMENTATION_LOCATIONS = List.of("./openapi/traceability-foss-backend.json",
             "../docs/api/traceability-foss-backend.json");
 
     @Test
-    void shouldGenerateOpenapiDocumentation() {
+    void shouldGenerateOpenApiDoc() {
         // when
         var response = given()
                 .when()
@@ -53,6 +55,5 @@ class OpenApiDocumentationIT extends IntegrationTestSpecification {
                 throw new RuntimeException(e);
             }
         });
-        ;
     }
 }


### PR DESCRIPTION
- introduced property in integration tests' configuration to ignore test that unnecessarily updates OpenApi spec
- test is only executed in a github workflow now

resolves eclipse-tractusx/traceability-foss#
